### PR TITLE
Add thread-call fn and thread macro

### DIFF
--- a/src/clj/clojure/core/async.clj
+++ b/src/clj/clojure/core/async.clj
@@ -369,8 +369,8 @@
     c))
 
 (defmacro thread
-  "Synchronously executes the body in another thread, returning
-  immediately to the calling thread. Returns a channel which will
-  receive the result of the body when completed."
+  "Executes the body in another thread, returning immediately to the
+  calling thread. Returns a channel which will receive the result of
+  the body when completed."
   [& body]
   `(thread-call (fn [] ~@body)))


### PR DESCRIPTION
Notes:
- Added thread-call to keep the executor scope private to core.async namespace, mirroring the structure of (future <body>) and (future-call <fn>)
- put! with a closing callback to return the executing thread to the pool as soon as the body completes, rather than waiting for the caller to pick up the value (as we'd have to with >!!)
- If the fn in question has an uncaught throw, we don't communicate that to callers at all. Clients are always able to do their own communication of error conditions if they catch. Would it make sense to have a construct similar to (agent-error) like (thread-error <thread-chan>) which would convey an uncaught exception if one is encountered?
