### PR TITLE
Add constrained read/write-only ports

### DIFF
--- a/src/main/clojure/cljs/core/async.cljs
+++ b/src/main/clojure/cljs/core/async.cljs
@@ -37,6 +37,16 @@
   ([] (chan nil))
   ([buf-or-n] (channels/chan (if (number? buf-or-n) (buffer buf-or-n) buf-or-n))))
 
+(defn <port
+  "Returns a receive-only port wrapping the given channel."
+  [channel]
+  (channels/<port channel))
+
+(defn >port
+  "Returns a send-only port wrapping the given channel."
+  [channel]
+  (channels/>port channel))
+
 (defn timeout
   "Returns a channel that will close after msecs"
   [msecs]

--- a/src/main/clojure/cljs/core/async/impl/protocols.cljs
+++ b/src/main/clojure/cljs/core/async/impl/protocols.cljs
@@ -12,10 +12,10 @@
   (take! [port fn1-handler] "derefable val if taken, nil if take was enqueued"))
 
 (defprotocol WritePort
-  (put! [port val fn0-handler] "derefable nil if put, nil if put was enqueued. Must throw on nil val."))
-
-(defprotocol Channel
+  (put! [port val fn0-handler] "derefable nil if put, nil if put was enqueued. Must throw on nil val.")
   (close! [chan]))
+
+(defprotocol Channel)
 
 (defprotocol Handler
   (active? [h] "returns true if has callback. Must work w/o lock")

--- a/src/main/clojure/clojure/core/async.clj
+++ b/src/main/clojure/clojure/core/async.clj
@@ -58,6 +58,16 @@
   ([] (chan nil))
   ([buf-or-n] (channels/chan (if (number? buf-or-n) (buffer buf-or-n) buf-or-n))))
 
+(defn <port
+  "Returns a receive-only port wrapping the given channel."
+  [channel]
+  (channels/<port channel))
+
+(defn >port
+  "Returns a send-only port wrapping the given channel."
+  [channel]
+  (channels/>port channel))
+
 (defn timeout
   "Returns a channel that will close after msecs"
   [msecs]

--- a/src/main/clojure/clojure/core/async/impl/protocols.clj
+++ b/src/main/clojure/clojure/core/async/impl/protocols.clj
@@ -13,10 +13,10 @@
   (take! [port fn1-handler] "derefable val if taken, nil if take was enqueued"))
 
 (defprotocol WritePort
-  (put! [port val fn0-handler] "derefable nil if put, nil if put was enqueued. Must throw on nil val."))
-
-(defprotocol Channel
+  (put! [port val fn0-handler] "derefable nil if put, nil if put was enqueued. Must throw on nil val.")
   (close! [chan]))
+
+(defprotocol Channel)
 
 (defprotocol Handler
   (active? [h] "returns true if has callback. Must work w/o lock")

--- a/src/main/clojure/clojure/core/async/impl/timers.clj
+++ b/src/main/clojure/clojure/core/async/impl/timers.clj
@@ -35,10 +35,7 @@
        -1
        (if (= timestamp ostamp)
          0
-         1))))
-  impl/Channel
-  (close! [this]
-    (impl/close! channel)))
+         1)))))
 
 (defn timeout
   "returns a channel that will close after msecs"
@@ -59,7 +56,7 @@
     (loop []
       (let [^TimeoutQueueEntry tqe (.take q)]
         (.remove timeouts-map (.timestamp tqe) tqe)
-        (impl/close! tqe))
+        (impl/close! (.channel tqe)))
       (recur))))
 
 (defonce timeout-daemon

--- a/src/test/clojure/clojure/core/async_test.clj
+++ b/src/test/clojure/clojure/core/async_test.clj
@@ -117,3 +117,14 @@
            (put! c :enqueues #(deliver p :proceeded))  ;; enqueue a put
            (<!! c)        ;; make room in the buffer
            (deref p 250 :timeout)))))
+
+(deftest constrained-ports
+  (let [c (chan 1)
+        ro (<port c)
+        wo (>port c)]
+    (is (thrown? IllegalArgumentException (>!! ro :foo)))
+    (>!! wo :foo)
+    (is (thrown? IllegalArgumentException (<!! wo)))
+    (is (= (<!! ro) :foo))
+    (is (thrown? IllegalArgumentException (close! ro)))
+    (close! wo)))


### PR DESCRIPTION
As discussed in IRC today, this adds support for read-only and write-only "ports", which are constrained wrappers around channels. Write-only ports allow both put and close operations, were as read-only ports allow only take operations. Unsupported operations throw.

I'm open to suggestions for better names than `<port` and `>port`.
