### PR TITLE
Modify require expression in walkthrough

### DIFF
--- a/examples/walkthrough.clj
+++ b/examples/walkthrough.clj
@@ -1,7 +1,9 @@
 ;; This walkthrough introduces the core concepts of core.async.
 
 ;; The clojure.core.async namespace contains the public API.
-(require '[clojure.core.async :as async :refer :all])
+(require '[clojure.core.async :as async 
+                              :refer :all
+                              :exclude [map merge into reduce]])
 
 ;;;; CHANNELS
 


### PR DESCRIPTION
Given :refer :all will cause collisions with clojure.core functions, making the walkthrough require more explicit helps document what I think is likely to be a fairly common require situation for users who are new to the library.
