### PR TITLE
ASYNC-41: Make mult drop values when there are no taps

### DIFF
--- a/src/main/clojure/cljs/core/async.cljs
+++ b/src/main/clojure/cljs/core/async.cljs
@@ -447,7 +447,8 @@
                    (swap! dctr dec)
                    (untap* m c))))
            ;;wait for all
-           (<! dchan)
+           (when (seq chs)
+             (<! dchan))
            (recur)))))
     m))
 


### PR DESCRIPTION
http://dev.clojure.org/jira/browse/ASYNC-41

If you have a mult and you put a value on its source channel, but there are no taps at the moment, the mult will get stuck and not put any values on future tap channels. Here's an example: http://cljsfiddle.net/fiddle/rads.mult-bug
