### PR TITLE
Support (try (catch :default)) in CLJS exception handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :parent [org.clojure/pom.contrib "0.1.2"]
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-1978"]]
+                 [org.clojure/clojurescript "0.0-2080"]]
   :global-vars {*warn-on-reflection* true}
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure"]

--- a/src/main/clojure/cljs/core/async/impl/ioc_helpers.cljs
+++ b/src/main/clojure/cljs/core/async/impl/ioc_helpers.cljs
@@ -102,7 +102,8 @@
 
      (and exception
           catch-block
-          (instance? catch-exception exception))
+          (or (= :default catch-exception)
+              (instance? catch-exception exception)))
      (ioc/aset-all! state
                     STATE-IDX
                     catch-block

--- a/src/test/cljs/cljs/core/async/runner_tests.cljs
+++ b/src/test/cljs/cljs/core/async/runner_tests.cljs
@@ -162,6 +162,12 @@
             (assert false)
             (catch js/Error ex 42))))
 
+    (is= 42
+         (runner
+          (try
+            (assert false)
+            (catch :default ex 42))))
+
     (let [a (atom false)
           v (runner
              (try


### PR DESCRIPTION
Bump CLJS version to one that supports :default. This should be
backwards compatible with the old version, but the tests don't run
without bumping the dependency.
