### PR TITLE
Fall back to process.nextTick in queue-dispatcher

### DIFF
--- a/src/main/clojure/cljs/core/async/impl/dispatch.cljs
+++ b/src/main/clojure/cljs/core/async/impl/dispatch.cljs
@@ -36,6 +36,7 @@
     (cond
      (exists? js/MessageChannel) (.postMessage (.-port2 message-channel) 0)
      (exists? js/setImmediate) (js/setImmediate process-messages)
+     (and (exists? js/process) (exists? (.-nextTick js/process))) (.nextTick js/process process-messages)
      :else (js/setTimeout process-messages 0))))
 
 (defn run [f]


### PR DESCRIPTION
If we can't find MessageChannel or setImmediate use nextTick.

discussion here:

https://groups.google.com/forum/#!searchin/clojurescript/nextTick/clojurescript/RW1FMv0UoPE/hsMHI4SLKXYJ

discussion of the differences between setImmediate and nextTick here:

http://stackoverflow.com/questions/15349733/setimmediate-vs-nexttick
