### PR TITLE
Fix property access syntax inside go blocks

### DIFF
--- a/src/main/clojure/cljs/core/async/impl/ioc_macros.clj
+++ b/src/main/clojure/cljs/core/async/impl/ioc_macros.clj
@@ -290,7 +290,9 @@
   (block-references [this] [])
   IEmittableInstruction
   (emit-instruction [this state-sym]
-    `[~(:id this) (. ~target ~(cons method args))]))
+    (if (.startsWith (name method) "-")
+      `[~(:id this) (. ~target ~method)]
+      `[~(:id this) (. ~target ~(cons method args))])))
 
 (defrecord Jmp [value block]
   IInstruction

--- a/src/test/cljs/cljs/core/async/runner_tests.cljs
+++ b/src/test/cljs/cljs/core/async/runner_tests.cljs
@@ -102,6 +102,12 @@
     (runner (set! test-target 42))
     (is= test-target 42))
 
+  (testing "property access"
+    (let [x (js-obj)]
+      (set! (.-foo x) 42)
+      (is= 42 (runner (.-foo x)))
+      (is= 42 (runner (. x -foo)))))
+
   (testing "keywords as functions"
     (is (= :bar
            (runner (:foo (pause {:foo :bar}))))))


### PR DESCRIPTION
We need to special case ClojureScript's property access syntax.
