### PR TITLE
Update lab.clj

### DIFF
--- a/src/main/clojure/clojure/core/async/lab.clj
+++ b/src/main/clojure/clojure/core/async/lab.clj
@@ -77,7 +77,7 @@
   available to be read from, parks execution until a value is
   available."
   [& ports]
-  (->MultiplexingReadPort (mutex/mutex) (HashSet. ^Collection ports)))
+  (->MultiplexingReadPort (mutex/mutex) (HashSet. ^Collection (or ports []))))
 
 (defn- broadcast-write
   [port-set val handler]


### PR DESCRIPTION
In order to avoid a null pointer exception when calling (clojure.core.async.lab/multiplex)
