### PR TITLE
Fixed inconsistent thread pool in pipeline function

### DIFF
--- a/src/main/clojure/clojure/core/async.clj
+++ b/src/main/clojure/clojure/core/async.clj
@@ -483,10 +483,10 @@
                        true)))]
        (dotimes [_ n]
          (case type
-               :blocking (thread
+               :blocking (thread (loop[]
                           (let [job (<!! jobs)]
                             (when (process job)
-                              (recur))))
+                              (recur)))))
                :compute (go-loop []
                                    (let [job (<! jobs)]
                                      (when (process job)


### PR DESCRIPTION
Hi there,
While reading the code I came across this weird inconsistency - in `pipeline*` function for the `:blocking` processing there is no loop within each thread - while for the async processing there is always a `go-loop []` which can be re-written as `(go (loop []...`, for sync processing there is only "thread" macro with no loop in it and with a recur call at the end. I am not sure where this recur call will lead to (haven't tested it), but even if it jumps back to the thread macro it might lead to unexpected behavior (each thread being recreated after every iteration) and if it jumps elsewhere it might lead to the thread halting after only one iteration is performed. Therefore I would suggest using `(thread (loop [] ... (recur)))` as opposed to `(thread .... (recur))` and also as it much better corresponds to `(go (loop [] ... (recur)))` (aka `go-loop`) which is used for `:compute` and `:async` types.
I'm still quite new to core.async so please test my change thoroughly :)
Cheers
Miro