### PR TITLE
RFC: Add macro aliases in cljs.core.async

### DIFF
--- a/src/main/clojure/cljs/core/async.clj
+++ b/src/main/clojure/cljs/core/async.clj
@@ -1,0 +1,6 @@
+(ns cljs.core.async
+  (:require [cljs.core.async.macros :as m]))
+
+(defmacro alt! [& x] `(m/alt! ~@x))
+(defmacro go [& x] `(m/go ~@x))
+(defmacro go-loop [& x] `(m/go-loop ~@x))

--- a/src/test/cljs/cljs/core/async/pipeline_test.cljs
+++ b/src/test/cljs/cljs/core/async/pipeline_test.cljs
@@ -1,8 +1,8 @@
 (ns cljs.core.async.pipeline-test
-  (:require-macros [cljs.core.async.macros :as m :refer [go go-loop]])
   (:require [cljs.core.async.test-helpers :refer [latch inc!]]
             [cljs.core.async :as a
-             :refer [<! >! chan close! to-chan pipeline-async pipeline put!]]
+             :refer [<! >! chan close! to-chan pipeline-async pipeline put!]
+             :refer-macros [go go-loop]]
             [cljs.test :refer-macros [deftest is testing async]]))
 
 (defn pipeline-tester [pipeline-fn n inputs xf]

--- a/src/test/cljs/cljs/core/async/tests.cljs
+++ b/src/test/cljs/cljs/core/async/tests.cljs
@@ -1,10 +1,9 @@
 (ns cljs.core.async.tests
-  (:require-macros
-   [cljs.core.async.macros :as m :refer [go alt!]])
   (:require
    [cljs.core.async :refer
     [buffer dropping-buffer sliding-buffer put! take! chan promise-chan
-     close! take partition-by offer! poll!] :as async]
+     close! take partition-by offer! poll!]
+    :refer-macros [go alt!] :as async]
    [cljs.core.async.impl.dispatch :as dispatch]
    [cljs.core.async.impl.buffers :as buff]
    [cljs.core.async.impl.timers :as timers :refer [timeout]]


### PR DESCRIPTION
Hi!

I'd like to be able to use:

```
  (:require [cljs.core.async :refer-macros [...]])
```

Instead of needing a separate clause like:

```
  (:require-macros [cljs.core.async :refer-macros [...]])
```

The former seems more idiomatic in modern ClojureScript.

I mark the pull request as RFC, because I am unsure the way I am doing aliases is the best. Other ways, which also copy metadata, like the old `defalias` seemed too ugly. In the long term I guess just moving the `macros.clj` file would be the right thing to do, but aliases might be better for backwards compatiblity.

Cheers!
