### PR TITLE
[ASYNC-251] a/timeout can overflow

### DIFF
--- a/src/main/clojure/cljs/core/async/impl/timers.cljs
+++ b/src/main/clojure/cljs/core/async/impl/timers.cljs
@@ -166,7 +166,11 @@
 (defn timeout
   "returns a channel that will close after msecs"
   [msecs]
-  (let [timeout (+ (.valueOf (js/Date.)) msecs)
+  (let [current-time (.valueOf (js/Date.))
+        max-timeout (-> 24 (* 60) (* 60) (* 1000))
+        timeout (if (>= msecs max-timeout)
+                  (+ current-time max-timeout)
+                  (+ current-time msecs))
         me (.ceilingEntry timeouts-map timeout)]
     (or (when (and me (< (.-key me) (+ timeout TIMEOUT_RESOLUTION_MS)))
           (.-val me))
@@ -176,5 +180,5 @@
             (fn []
               (.remove timeouts-map timeout)
               (impl/close! timeout-channel))
-            msecs)
+            (min msecs max-timeout))
           timeout-channel))))


### PR DESCRIPTION
This PR attempts to solve [ASYNC-251](https://clojure.atlassian.net/jira/software/c/projects/ASYNC/issues/ASYNC-251) by applying caution when using the `clojure.core.async.impl.timers.timeout` function, adding a maximum timeout limit of 24 hours.

This may not be the best approach to solve the problem, but it was the most practical one I had thought of taking into account the caution with possible overflows. If you have a better approach in mind, please let me know so I can continue developing this fix in the best way possible.

Thanks in advance and thanks for the amazing work the team has done!